### PR TITLE
Invert output of ridge detection

### DIFF
--- a/src/main/java/uk/ac/franciscrickinstitute/twombli/TWOMBLIRunner.java
+++ b/src/main/java/uk/ac/franciscrickinstitute/twombli/TWOMBLIRunner.java
@@ -216,7 +216,8 @@ public class TWOMBLIRunner implements Command {
         ImagePlus output = this.multiScaleRidgeDetection(ridgeDetectionBaseImage);
 
         // Invert LUTs
-        IJ.run(output, "Invert LUT", "");
+        IJ.run(output, "Grays", "");
+        IJ.run(output, "Invert", "");
 
         // Handle outputs
         IJ.saveAs(output, "png", maskImage);


### PR DESCRIPTION
Hi @JonathanCSmith,

There's a slight error here (a quirk of FIJI), which meant that the input to the AnaMorf runs was the inverse of what it should be. Something similar to what I've done here should rectify the problem.