### PR TITLE
Add number of branches and endpoints to output

### DIFF
--- a/src/main/java/uk/ac/franciscrickinstitute/twombli/TWOMBLIRunner.java
+++ b/src/main/java/uk/ac/franciscrickinstitute/twombli/TWOMBLIRunner.java
@@ -348,8 +348,8 @@ public class TWOMBLIRunner implements Command {
             Batch_Analyser.getProps().setProperty(DefaultParams.FOURIER_FRAC_LABEL, "false");
             Batch_Analyser.getProps().setProperty(DefaultParams.LAC_LABEL, "false");
             Batch_Analyser.getProps().setProperty(DefaultParams.MEAN_BRANCH_LABEL, "false");
-            Batch_Analyser.getProps().setProperty(DefaultParams.NUM_BRANCH_LABEL, "false");
-            Batch_Analyser.getProps().setProperty(DefaultParams.NUM_END_LABEL, "false");
+            Batch_Analyser.getProps().setProperty(DefaultParams.NUM_BRANCH_LABEL, "true");
+            Batch_Analyser.getProps().setProperty(DefaultParams.NUM_END_LABEL, "true");
             Batch_Analyser.getProps().setProperty(DefaultParams.PROJ_AREA_LABEL, "false");
             Batch_Analyser.getProps().setProperty(DefaultParams.TOT_LENGTH_LABEL, "false");
 


### PR DESCRIPTION
I think this relatively small change is all that is required to ensure the number of branches and number of endpoints appears in the twombli_summary.csv output